### PR TITLE
verfying authorizeUser

### DIFF
--- a/src/auth/jwt/handler.go
+++ b/src/auth/jwt/handler.go
@@ -9,6 +9,7 @@ import (
 func MakeHTTPHandler() http.Handler {
 	router := httprouter.New()
 	router.HandlerFunc("POST", "/auth/sign_in", AuthenticateSignIn)
+	router.HandlerFunc("GET", "/auth/testAuthen", AuthenticateUser)
 	router.HandlerFunc("GET", "/auth/refresh", Refresh)
 	router.HandlerFunc("GET", "/auth/sign_out", SignOut)
 

--- a/src/modulegroup_management/services.go
+++ b/src/modulegroup_management/services.go
@@ -1,7 +1,6 @@
 package modulegroup_management
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -13,16 +12,4 @@ type DemoJson struct {
 
 func GetAllModuleGroup(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Hello World!")
-}
-
-func GetDemoJson(w http.ResponseWriter, r *http.Request) {
-	demoJson := DemoJson{"Name", []string{"item 1", "item 2"}}
-	js, err := json.Marshal(demoJson)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
 }


### PR DESCRIPTION
In authorize user and some other functions that I haven't edited, 
	token, err := jwt.ParseWithClaims(tokenString, claims,
		func(token *jwt.Token) (interface{}, error) {
			return []byte(jwtKey), nil
		})
you need to add []byte to check otherwise you'll get a invalid key error
-I've adjusted some Authenticate Signin but the working of code is the same
-I've added the default secretkey to be 's' first since there is no .env file yet and if there's no secret key, then I cannot do the checking